### PR TITLE
Add suggestions for nearby restaurants and cafes

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -33,6 +33,7 @@ function App() {
   const [sunset, setSunset] = useState("");
   const [timezone, setTimezone] = useState("");
   const [weatherType, setWeatherType] = useState("");
+  const [restaurant, setRestaurant] = useState([]);
 
   const findUserLocation = position => {
     const latitude = position.coords.latitude,
@@ -78,6 +79,20 @@ function App() {
     }, 200);
   };
 
+  const searchNearbyRestaurants = () => {
+    fetch(`https://api.geoapify.com/v2/places?categories=catering.restaurant,catering.cafe&filter=circle:-${coordinates.lon},${coordinates.lat}&bias=proximity:-${coordinates.lon},${coordinates.lat}&limit=20&apiKey=${process.env.REACT_APP_PLACES}`)
+    .then(res => res.json())
+    .then((res) => {
+      const ci = [];
+      // for debugging
+        res.forEach((item) => {
+          ci.push(item.type);
+        });
+        setRestaurant(ci);
+      console.log(ci);
+    });
+  }
+  
   useEffect(() => {
     if (navigator.geolocation) {
       navigator.geolocation.getCurrentPosition(findUserLocation);
@@ -238,6 +253,13 @@ function App() {
           <Alerts city={city} />
         </div>
         <Footer />
+        <Alerts city={city} />
+
+        {searchNearbyRestaurants}
+        {restaurant}
+        {/* { restaurant.map(() => (
+              <p>{restaurant}</p>
+            ))} */}
       </div>
     </>
   );

--- a/src/App.js
+++ b/src/App.js
@@ -95,7 +95,6 @@ function App() {
             lon: place.properties.lon
           });
         });
-      // console.log(restaurants);
       setNearbyRestaurants(restaurants);
       setIsPlacesLoaded(true);
     });
@@ -175,7 +174,6 @@ function App() {
         let tempPlaces = [];
         data.features.forEach(place => {
           const temp = {
-            type: "place",
             name: place.properties.name,
             address:
               place.properties.address_line1 + place.properties.address_line2,
@@ -187,7 +185,6 @@ function App() {
         tempPlaces = [
           ...tempPlaces,
           {
-            type: "place",
             name: "Your Location",
             address: "You are here!",
             lat: coordinates.lat,

--- a/src/App.js
+++ b/src/App.js
@@ -97,6 +97,11 @@ function App() {
         });
       setNearbyRestaurants(restaurants);
       setIsPlacesLoaded(true);
+    })
+    .catch((err) => {
+        setIsLoaded(false);
+        setIsPlacesLoaded(false);
+        setError(err);
     });
   }
   

--- a/src/components/Places/PlaceMarker.js
+++ b/src/components/Places/PlaceMarker.js
@@ -22,15 +22,26 @@ const greenMarker = new L.Icon({
 	shadowSize: [41, 41],
 });
 
+const restaurantMarker = new L.Icon({
+	iconUrl:
+		'https://cdn.jsdelivr.net/gh/pointhi/leaflet-color-markers@master/img/marker-icon-2x-violet.png',
+	shadowUrl:
+		'https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.7/images/marker-shadow.png',
+	iconSize: [25, 41],
+	iconAnchor: [12, 41],
+	popupAnchor: [1, -34],
+	shadowSize: [41, 41],
+});
+
 export default function PlaceMarker({coordinates, places}) {
     const map = useMap();
 
     map.setView(coordinates);
 
-    return places.map((place)=>{
+    return places.map((place, idx)=>{
         if(place.lat===coordinates.lat && place.lon===coordinates.lon){
             return (
-                <Marker position={[place.lat, place.lon]} icon={defaultMarker}>
+                <Marker key={idx} position={[place.lat, place.lon]} icon={defaultMarker}>
                     <Popup>
                         <h4>{place.name}</h4>
                         <p>{place.address}</p>
@@ -39,7 +50,7 @@ export default function PlaceMarker({coordinates, places}) {
             )
         } else {
             return (
-                <Marker position={[place.lat, place.lon]} icon={greenMarker}>
+                <Marker key={idx} position={[place.lat, place.lon]} icon={place.type === "restaurant"? restaurantMarker: greenMarker}>
                     <Popup>
                         <h1>{place.name}</h1>
                         <h2>Address</h2>


### PR DESCRIPTION
This PR resolves issue #42 and makes the following changes:
- Integrate an API call to the geoApify Places API to fetch data of nearby restaurants. Kudos to @Swatishree-Mahapatra and @aku1310 for this change.
- Show the nearby restaurants using a different marker on the Map.

PS: No new API has been added hence no need to add any API key, we are using the existing geoAPify Places API itself to do this.